### PR TITLE
feat(translation): support dead keys for circumflex and diaeresis accents

### DIFF
--- a/src/ydotool-translate.sh
+++ b/src/ydotool-translate.sh
@@ -52,40 +52,40 @@ translate_azerty_to_qwerty() {
             'Ù') result+="'" ;;   # AZERTY Ù → QWERTY '
             
             # ===== ACCENTED VOWELS =====
-            # Circumflex accent (lowercase)
-            'â') result+='q' ;;   # AZERTY â → QWERTY q
-            'ê') result+='e' ;;   # AZERTY ê → QWERTY e
-            'î') result+='i' ;;   # AZERTY î → QWERTY i
-            'ô') result+='o' ;;   # AZERTY ô → QWERTY o
-            'û') result+='u' ;;   # AZERTY û → QWERTY u
-            
+            # Circumflex accent (lowercase) - dead key ^ = [ on QWERTY
+            'â') result+='[q' ;;  # ^ (dead) + a → [ + q
+            'ê') result+='[e' ;;  # ^ (dead) + e → [ + e
+            'î') result+='[i' ;;  # ^ (dead) + i → [ + i
+            'ô') result+='[o' ;;  # ^ (dead) + o → [ + o
+            'û') result+='[u' ;;  # ^ (dead) + u → [ + u
+
             # Circumflex accent (uppercase)
-            'Â') result+='Q' ;;
-            'Ê') result+='E' ;;
-            'Î') result+='I' ;;
-            'Ô') result+='O' ;;
-            'Û') result+='U' ;;
-            
-            # Diaeresis/Umlaut (lowercase)
-            'ä') result+='q' ;;
-            'ë') result+='e' ;;
-            'ï') result+='i' ;;
-            'ö') result+='o' ;;
-            'ü') result+='u' ;;
-            
+            'Â') result+='[Q' ;;
+            'Ê') result+='[E' ;;
+            'Î') result+='[I' ;;
+            'Ô') result+='[O' ;;
+            'Û') result+='[U' ;;
+
+            # Diaeresis/Umlaut (lowercase) - dead key ¨ = Shift+^ = { on QWERTY
+            'ä') result+='{q' ;;
+            'ë') result+='{e' ;;
+            'ï') result+='{i' ;;
+            'ö') result+='{o' ;;
+            'ü') result+='{u' ;;
+
             # Diaeresis/Umlaut (uppercase)
-            'Ä') result+='Q' ;;
-            'Ë') result+='E' ;;
-            'Ï') result+='I' ;;
-            'Ö') result+='O' ;;
-            'Ü') result+='U' ;;
-            
-            # Acute accent (lowercase)
+            'Ä') result+='{Q' ;;
+            'Ë') result+='{E' ;;
+            'Ï') result+='{I' ;;
+            'Ö') result+='{O' ;;
+            'Ü') result+='{U' ;;
+
+            # Acute accent (lowercase) - no dead key on AZERTY, fallback to base letter
             'á') result+='q' ;;
             'í') result+='i' ;;
             'ó') result+='o' ;;
             'ú') result+='u' ;;
-            
+
             # Acute accent (uppercase)
             'Á') result+='Q' ;;
             'Í') result+='I' ;;
@@ -309,8 +309,8 @@ if [ "$file_mode" -eq 1 ]; then
         } >> /tmp/ydotool-translate-debug.log
     fi
 
-    # Pass translated content to ydotool-real via stdin
-    echo "$translated" | /usr/bin/ydotool-real type "${options[@]}" --file -
+    # Pass translated content to ydotool-real via stdin (without adding newline)
+    printf '%s' "$translated" | /usr/bin/ydotool-real type "${options[@]}" --file -
     exit $?
 fi
 


### PR DESCRIPTION
## Summary

- Utilise les séquences de touches mortes AZERTY au lieu de supprimer les accents
  - **Circumflexe** (â ê î ô û) : envoie la touche morte `^` (`[` en QWERTY) + voyelle
  - **Tréma** (ä ë ï ö ü) : envoie la touche morte `¨` (`{` en QWERTY) + voyelle
- Corrige le mode fichier : utilise `printf '%s'` au lieu de `echo` pour éviter un retour à la ligne parasite

## Problème

Actuellement, les caractères accentués comme `â` sont mappés vers leur lettre de base (`q` en position QWERTY), ce qui perd l'accent. Par exemple, `ydotool type "forêt"` produit `foret` au lieu de `forêt`.

## Solution

Au lieu de mapper directement vers la lettre de base, on simule la séquence de touches mortes réelle :
- Sur AZERTY, `â` se tape avec `^` (touche morte) puis `a`
- La touche `^` sur AZERTY correspond à `[` sur QWERTY
- La touche `a` sur AZERTY correspond à `q` sur QWERTY
- Donc on envoie `[q` à ydotool, qui simule `^` + `a` → `â`

Même logique pour le tréma (`¨` = Shift+`^` = `{` sur QWERTY).

## Test

Testé sur un système AZERTY avec ydotool + ydotoold :
```bash
# Avant : "foret" (accent perdu)
# Après : "forêt" (accent préservé)
ydotool type "la forêt où l'île rôtie"

# Trémas fonctionnent aussi
ydotool type "äëïöü"
```