### PR TITLE
fix(install): copy scripts to /usr/bin/ instead of using symlinks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,12 +31,14 @@ fi
 
 # Install the wrapper
 echo "Installing ydotool wrapper..."
-ln -sf "$SCRIPT_DIR/src/ydotool-wrapper.sh" /usr/bin/ydotool
-chmod +x "$SCRIPT_DIR/src/ydotool-wrapper.sh"
+cp "$SCRIPT_DIR/src/ydotool-wrapper.sh"  /usr/bin/ydotool-wrapper.sh
+cp "$SCRIPT_DIR/src/ydotool-translate.sh"  /usr/bin/ydotool-translate.sh
+ln -sf /usr/bin/ydotool-wrapper.sh /usr/bin/ydotool
+chmod +x /usr/bin/ydotool-wrapper.sh
 
 # Make the translator executable
 echo "Setting up AZERTY to QWERTY translator..."
-chmod +x "$SCRIPT_DIR/src/ydotool-translate.sh"
+chmod +x /usr/bin/ydotool-translate.sh
 
 echo ""
 echo "✅ Installation successful!"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -16,6 +16,8 @@ fi
 if [ -f /usr/bin/ydotool-real ]; then
     echo "Restoring real ydotool..."
     rm -f /usr/bin/ydotool
+    rm -f /usr/bin/ydotool-wrapper.sh
+    rm -f /usr/bin/ydotool-translate.sh
     mv /usr/bin/ydotool-real /usr/bin/ydotool
 else
     echo "/usr/bin/ydotool-real not found"


### PR DESCRIPTION
## Summary

- Copie les scripts (`ydotool-wrapper.sh`, `ydotool-translate.sh`) dans `/usr/bin/` au lieu de créer des symlinks vers le répertoire source
- Met à jour `uninstall.sh` pour supprimer les fichiers copiés

## Problème

L'installation actuelle crée un symlink `/usr/bin/ydotool` → `$SCRIPT_DIR/src/ydotool-wrapper.sh`. Le wrapper utilise `readlink -f` pour trouver le traducteur dans le même répertoire.

Cela pose problème si :
- Le répertoire source est supprimé ou déplacé après installation → ydotool casse
- Le répertoire source est sur un volume amovible (clé USB, etc.)
- Un autre utilisateur clone le repo ailleurs et l'ancien chemin ne correspond plus

## Solution

Copier les scripts directement dans `/usr/bin/` rend l'installation autonome :

```bash
# Avant (symlink, dépend du répertoire source)
ln -sf "$SCRIPT_DIR/src/ydotool-wrapper.sh" /usr/bin/ydotool

# Après (copie, installation autonome)
cp "$SCRIPT_DIR/src/ydotool-wrapper.sh"  /usr/bin/ydotool-wrapper.sh
cp "$SCRIPT_DIR/src/ydotool-translate.sh"  /usr/bin/ydotool-translate.sh
ln -sf /usr/bin/ydotool-wrapper.sh /usr/bin/ydotool
```

Le `uninstall.sh` est aussi mis à jour pour nettoyer ces fichiers.