### PR TITLE
feat: support multi-layout (fr, de, be, it, es)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,11 +82,22 @@ Requires: root access, `ydotool` pre-installed, Bash 4.0+
 sudo ./uninstall.sh
 ```
 
+### Installation via .deb
+```bash
+sudo dpkg -i ydotool-rebind_1.1.0_all.deb
+# Désinstallation :
+sudo dpkg -r ydotool-rebind
+```
+
 ### Testing
 ```bash
 # Manual testing
 ydotool type "Bonjour, ça va ?"
 ydotool type "éèàù çœæ"
+
+# Dead keys testing (circumflex and diaeresis)
+ydotool type "la forêt où l'île rôtie"
+ydotool type "âêîôû äëïöü"
 
 # File mode testing (translates file content)
 echo "Bonjour" > /tmp/test.txt
@@ -97,6 +108,13 @@ echo "Bonjour" | ydotool type -f -
 # Debug mode (logs to /tmp/ydotool-translate-debug.log)
 DEBUG=1 ydotool type "test"
 DEBUG=1 ydotool type -f /tmp/test.txt
+```
+
+### Building .deb
+```bash
+# Structure: /tmp/ydotool-rebind_VERSION/DEBIAN/{control,postinst,prerm} + usr/bin/{scripts}
+dpkg-deb --build /tmp/ydotool-rebind_VERSION /tmp/ydotool-rebind_VERSION_all.deb
+# Publish: gh release create vVERSION file.deb --repo rcspam/ydotool-rebind
 ```
 
 Note: The README mentions `./test.sh` but no test script exists in the repository.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,155 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**ydotool-rebind** is a wrapper system for `ydotool` that translates AZERTY keyboard input to QWERTY layout. The `ydotool` tool internally uses QWERTY layout regardless of system keyboard configuration, causing incorrect text output on AZERTY systems. This wrapper intercepts `ydotool type` commands and translates the input before passing it to the real binary.
+
+### Core Problem
+
+- `ydotool` always uses QWERTY internally
+- AZERTY users typing "Bonjour" would see "Vonjout" typed
+- This wrapper translates: AZERTY input → QWERTY equivalent → correct output
+
+## Architecture
+
+### Components
+
+1. **ydotool-wrapper.sh** (`src/ydotool-wrapper.sh`)
+   - Replaces the system `ydotool` binary via symlink
+   - Intercepts all `ydotool` commands
+   - Routes `type` commands to the translator
+   - Passes all other commands directly to `ydotool-real`
+
+2. **ydotool-translate.sh** (`src/ydotool-translate.sh`)
+   - Character-by-character AZERTY → QWERTY translation engine
+   - Handles all French AZERTY characters including:
+     - Number row symbols (& é " ' ( - è _ ç à)
+     - Letter position mappings (a↔q, z↔w, w↔z, m↔;, etc.)
+     - French accents (é è à ù ç and circumflex/diaeresis variants)
+     - Special ligatures (œ æ)
+   - Preserves `ydotool type` command options (-d, -H, -D, -f, -e)
+   - File mode (-f) translates file content before passing to ydotool (supports stdin with `-f -`)
+
+3. **Installation System**
+   - `install.sh`: Renames `/usr/bin/ydotool` → `/usr/bin/ydotool-real`, copies wrapper and translator to `/usr/bin/`, creates symlink
+   - `uninstall.sh`: Removes wrapper/translator files and restores original binary
+
+### Execution Flow
+
+**Direct Text Mode:**
+```
+User: ydotool type "Bonjour"
+  ↓
+ydotool-wrapper.sh (at /usr/bin/ydotool)
+  ↓ (detects "type" command)
+ydotool-translate.sh
+  ↓ (translates character-by-character)
+  "Bonjour" → "Vonjout" (AZERTY→QWERTY mapping)
+  ↓
+/usr/bin/ydotool-real type "Vonjout"
+  ↓ (ydotool interprets as QWERTY)
+Output: "Bonjour" ✓
+```
+
+**File Mode:**
+```
+User: ydotool type -f /tmp/test.txt (contains "Bonjour")
+  ↓
+ydotool-wrapper.sh (at /usr/bin/ydotool)
+  ↓ (detects "type" command)
+ydotool-translate.sh
+  ↓ (reads file content)
+  ↓ (translates content)
+  "Bonjour" → "Vonjout" (AZERTY→QWERTY mapping)
+  ↓
+/usr/bin/ydotool-real type --file - (receives translated content via stdin)
+  ↓ (ydotool interprets as QWERTY)
+Output: "Bonjour" ✓
+```
+
+## Commands
+
+### Installation
+```bash
+sudo ./install.sh
+```
+Requires: root access, `ydotool` pre-installed, Bash 4.0+
+
+### Uninstallation
+```bash
+sudo ./uninstall.sh
+```
+
+### Testing
+```bash
+# Manual testing
+ydotool type "Bonjour, ça va ?"
+ydotool type "éèàù çœæ"
+
+# File mode testing (translates file content)
+echo "Bonjour" > /tmp/test.txt
+ydotool type -f /tmp/test.txt
+# Or from stdin:
+echo "Bonjour" | ydotool type -f -
+
+# Debug mode (logs to /tmp/ydotool-translate-debug.log)
+DEBUG=1 ydotool type "test"
+DEBUG=1 ydotool type -f /tmp/test.txt
+```
+
+Note: The README mentions `./test.sh` but no test script exists in the repository.
+
+## Character Translation Logic
+
+The translator uses a large `case` statement in `translate_azerty_to_qwerty()` function:
+
+- **Number row**: Maps AZERTY symbols to QWERTY equivalents (e.g., `&` → `1`, `é` → `2`)
+- **Letter swaps**: Key position differences (e.g., AZERTY `a` is where QWERTY `q` is)
+- **Accented characters**: Uses dead key sequences for circumflex (`^` = `[` on QWERTY) and diaeresis (`¨` = `{` on QWERTY), falls back to base letter for other accents
+- **Ligatures**: Expands to multi-character (e.g., `œ` → `oe`)
+- **Passthrough**: Most symbols and all unrecognized characters pass unchanged
+
+### Critical Mappings
+- Letter row: `azerty...` → `qwerty...`
+- Home row: `qsdfg...m` → `asdfg...;`
+- Bottom row: `wxcvbn,;:` → `zxcvbn,;.`
+
+## File Structure
+
+```
+ydotool-rebind/
+├── src/
+│   ├── ydotool-wrapper.sh      # Main wrapper (copied to /usr/bin/, symlinked to /usr/bin/ydotool)
+│   └── ydotool-translate.sh    # Translation engine
+├── install.sh                   # Installation script
+├── uninstall.sh                 # Uninstallation script
+└── README.md
+```
+
+## Implementation Notes
+
+### When Modifying Translation Logic
+
+1. The translator is mostly stateless - each character is translated independently (circumflex/diaeresis produce 2-character dead key sequences)
+2. Order matters in the `case` statement (first match wins)
+3. Some characters appear multiple times with different contexts (e.g., `&` as both AZERTY unshifted and shifted)
+4. Test with actual AZERTY keyboard input to verify correctness
+5. The wrapper passes through all `ydotool` options unchanged
+6. File mode (`-f`) reads file content, translates it, then passes translated content to ydotool via stdin
+
+### System Integration
+
+- The wrapper and translator are copied to `/usr/bin/` and rely on absolute path `/usr/bin/ydotool-real`
+- Script resolution uses `readlink -f` to follow symlinks and find the translator in the same directory
+- Installation is idempotent (checks for existing `/usr/bin/ydotool-real`)
+- Requires root for system binary modification
+
+### Debug Output
+
+Enable with `DEBUG=1` environment variable:
+- Logs to `/tmp/ydotool-translate-debug.log`
+- Shows original text, translated text, and full command executed
+- File mode logs include file path, original content, and translated content
+- Useful for diagnosing translation issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**ydotool-rebind** is a wrapper system for `ydotool` that translates AZERTY keyboard input to QWERTY layout. The `ydotool` tool internally uses QWERTY layout regardless of system keyboard configuration, causing incorrect text output on AZERTY systems. This wrapper intercepts `ydotool type` commands and translates the input before passing it to the real binary.
+**ydotool-rebind** is a wrapper system for `ydotool` that translates keyboard input from non-QWERTY layouts to QWERTY. The `ydotool` tool internally uses QWERTY layout regardless of system keyboard configuration, causing incorrect text output on non-QWERTY systems. This wrapper intercepts `ydotool type` commands and translates the input before passing it to the real binary.
 
 ### Core Problem
 
 - `ydotool` always uses QWERTY internally
-- AZERTY users typing "Bonjour" would see "Vonjout" typed
-- This wrapper translates: AZERTY input → QWERTY equivalent → correct output
+- Non-QWERTY users get wrong characters (e.g., AZERTY "Bonjour" → "Vonjout")
+- This wrapper translates: source layout input → QWERTY equivalent → correct output
+
+### Supported Layouts
+
+| Layout | Type | Key differences |
+|--------|------|-----------------|
+| `fr` | AZERTY | a/q, z/w, m swaps, accents, number row symbols |
+| `de` | QWERTZ | z/y swap, umlauts (ö,ä,ü), ß, dead keys for accents |
+| `be` | AZERTY | Similar to FR, different number row (§, !, =) |
+| `it` | QWERTY-based | Accented vowels on special keys (è,é,ò,à,ù,ì) |
+| `es` | QWERTY-based | ñ, ç, ¡/¿, dead keys for all accents |
+| `us` | QWERTY | Passthrough (no translation) |
 
 ## Architecture
 
@@ -23,50 +34,39 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
    - Passes all other commands directly to `ydotool-real`
 
 2. **ydotool-translate.sh** (`src/ydotool-translate.sh`)
-   - Character-by-character AZERTY → QWERTY translation engine
-   - Handles all French AZERTY characters including:
-     - Number row symbols (& é " ' ( - è _ ç à)
-     - Letter position mappings (a↔q, z↔w, w↔z, m↔;, etc.)
-     - French accents (é è à ù ç and circumflex/diaeresis variants)
-     - Special ligatures (œ æ)
+   - Generic translation engine (layout-agnostic)
+   - `detect_layout()`: cascade YDOTOOL_LAYOUT → config → setxkbmap → localectl → fallback `fr`
+   - `load_layout()`: sources layout file (declares `KEYMAP` associative array)
+   - `translate_text()`: character-by-character translation using `KEYMAP[$char]` with passthrough fallback
+   - Short-circuits for `us` layout (no translation needed)
    - Preserves `ydotool type` command options (-d, -H, -D, -f, -e)
    - File mode (-f) translates file content before passing to ydotool (supports stdin with `-f -`)
 
-3. **Installation System**
-   - `install.sh`: Renames `/usr/bin/ydotool` → `/usr/bin/ydotool-real`, copies wrapper and translator to `/usr/bin/`, creates symlink
-   - `uninstall.sh`: Removes wrapper/translator files and restores original binary
+3. **Layout files** (`layouts/*.sh`)
+   - Each layout declares a `declare -A KEYMAP` associative array
+   - Only non-identity mappings (characters that differ from QWERTY)
+   - Support multi-character values for dead key sequences (e.g., `['â']='[q'`)
+   - Installed to `/etc/ydotool-rebind/layouts/`
+
+4. **Installation System**
+   - `install.sh`: Renames `/usr/bin/ydotool` → `/usr/bin/ydotool-real`, copies wrapper/translator to `/usr/bin/`, copies layouts to `/etc/ydotool-rebind/layouts/`, creates default config
+   - `uninstall.sh`: Removes wrapper/translator, layouts, config, restores original binary
 
 ### Execution Flow
 
-**Direct Text Mode:**
 ```
 User: ydotool type "Bonjour"
   ↓
 ydotool-wrapper.sh (at /usr/bin/ydotool)
   ↓ (detects "type" command)
 ydotool-translate.sh
-  ↓ (translates character-by-character)
-  "Bonjour" → "Vonjout" (AZERTY→QWERTY mapping)
+  ↓ detect_layout() → "fr"
+  ↓ load_layout("fr") → source /etc/ydotool-rebind/layouts/fr.sh
+  ↓ translate_text() → KEYMAP lookup per character
   ↓
-/usr/bin/ydotool-real type "Vonjout"
+/usr/bin/ydotool-real type "<translated>"
   ↓ (ydotool interprets as QWERTY)
-Output: "Bonjour" ✓
-```
-
-**File Mode:**
-```
-User: ydotool type -f /tmp/test.txt (contains "Bonjour")
-  ↓
-ydotool-wrapper.sh (at /usr/bin/ydotool)
-  ↓ (detects "type" command)
-ydotool-translate.sh
-  ↓ (reads file content)
-  ↓ (translates content)
-  "Bonjour" → "Vonjout" (AZERTY→QWERTY mapping)
-  ↓
-/usr/bin/ydotool-real type --file - (receives translated content via stdin)
-  ↓ (ydotool interprets as QWERTY)
-Output: "Bonjour" ✓
+Output: "Bonjour"
 ```
 
 ## Commands
@@ -84,90 +84,110 @@ sudo ./uninstall.sh
 
 ### Installation via .deb
 ```bash
-sudo dpkg -i ydotool-rebind_1.1.0_all.deb
-# Désinstallation :
+sudo dpkg -i ydotool-rebind_X.X.X_all.deb
+# Uninstall:
 sudo dpkg -r ydotool-rebind
+```
+
+### Configuration
+```bash
+# Set layout in config file
+echo "LAYOUT=de" | sudo tee /etc/ydotool-rebind/config
+
+# Or use environment variable (takes priority)
+YDOTOOL_LAYOUT=de ydotool type "Hallo Welt"
 ```
 
 ### Testing
 ```bash
-# Manual testing
+# French AZERTY
 ydotool type "Bonjour, ça va ?"
-ydotool type "éèàù çœæ"
-
-# Dead keys testing (circumflex and diaeresis)
-ydotool type "la forêt où l'île rôtie"
 ydotool type "âêîôû äëïöü"
 
-# File mode testing (translates file content)
+# German QWERTZ
+YDOTOOL_LAYOUT=de ydotool type "Hallo Welt"
+YDOTOOL_LAYOUT=de ydotool type "Grüße über Straße"
+
+# File mode
 echo "Bonjour" > /tmp/test.txt
 ydotool type -f /tmp/test.txt
-# Or from stdin:
 echo "Bonjour" | ydotool type -f -
 
-# Debug mode (logs to /tmp/ydotool-translate-debug.log)
+# Debug mode
 DEBUG=1 ydotool type "test"
-DEBUG=1 ydotool type -f /tmp/test.txt
 ```
 
 ### Building .deb
 ```bash
-# Structure: /tmp/ydotool-rebind_VERSION/DEBIAN/{control,postinst,prerm} + usr/bin/{scripts}
+# Structure: /tmp/ydotool-rebind_VERSION/DEBIAN/{control,postinst,prerm} + usr/bin/{scripts} + etc/ydotool-rebind/layouts/
 dpkg-deb --build /tmp/ydotool-rebind_VERSION /tmp/ydotool-rebind_VERSION_all.deb
-# Publish: gh release create vVERSION file.deb --repo rcspam/ydotool-rebind
 ```
-
-Note: The README mentions `./test.sh` but no test script exists in the repository.
-
-## Character Translation Logic
-
-The translator uses a large `case` statement in `translate_azerty_to_qwerty()` function:
-
-- **Number row**: Maps AZERTY symbols to QWERTY equivalents (e.g., `&` → `1`, `é` → `2`)
-- **Letter swaps**: Key position differences (e.g., AZERTY `a` is where QWERTY `q` is)
-- **Accented characters**: Uses dead key sequences for circumflex (`^` = `[` on QWERTY) and diaeresis (`¨` = `{` on QWERTY), falls back to base letter for other accents
-- **Ligatures**: Expands to multi-character (e.g., `œ` → `oe`)
-- **Passthrough**: Most symbols and all unrecognized characters pass unchanged
-
-### Critical Mappings
-- Letter row: `azerty...` → `qwerty...`
-- Home row: `qsdfg...m` → `asdfg...;`
-- Bottom row: `wxcvbn,;:` → `zxcvbn,;.`
 
 ## File Structure
 
 ```
 ydotool-rebind/
 ├── src/
-│   ├── ydotool-wrapper.sh      # Main wrapper (copied to /usr/bin/, symlinked to /usr/bin/ydotool)
-│   └── ydotool-translate.sh    # Translation engine
+│   ├── ydotool-wrapper.sh      # Main wrapper (copied to /usr/bin/)
+│   └── ydotool-translate.sh    # Generic translation engine
+├── layouts/
+│   ├── fr.sh                   # French AZERTY
+│   ├── de.sh                   # German QWERTZ
+│   ├── be.sh                   # Belgian AZERTY
+│   ├── it.sh                   # Italian
+│   └── es.sh                   # Spanish
 ├── install.sh                   # Installation script
 ├── uninstall.sh                 # Uninstallation script
 └── README.md
 ```
 
+Installed files:
+```
+/usr/bin/ydotool-wrapper.sh
+/usr/bin/ydotool-translate.sh
+/usr/bin/ydotool → symlink to ydotool-wrapper.sh
+/etc/ydotool-rebind/config          # LAYOUT=fr
+/etc/ydotool-rebind/layouts/*.sh    # Layout files
+```
+
 ## Implementation Notes
+
+### Adding a New Layout
+
+1. Create `layouts/xx.sh` with `declare -A KEYMAP=(...)`
+2. Only map characters that differ from QWERTY (passthrough handles the rest)
+3. For dead key accents, use multi-character values (e.g., `['â']='`a'` for circumflex via backtick dead key)
+4. Reference `/usr/share/X11/xkb/symbols/xx` for key positions
+5. Test with `YDOTOOL_LAYOUT=xx ydotool type "test text"`
+
+### Layout Detection Cascade
+
+1. `YDOTOOL_LAYOUT` environment variable (highest priority)
+2. `/etc/ydotool-rebind/config` file
+3. `setxkbmap -query` (X11 auto-detection)
+4. `localectl status` (systemd auto-detection)
+5. Fallback: `fr` (backward compatibility)
 
 ### When Modifying Translation Logic
 
-1. The translator is mostly stateless - each character is translated independently (circumflex/diaeresis produce 2-character dead key sequences)
-2. Order matters in the `case` statement (first match wins)
-3. Some characters appear multiple times with different contexts (e.g., `&` as both AZERTY unshifted and shifted)
-4. Test with actual AZERTY keyboard input to verify correctness
-5. The wrapper passes through all `ydotool` options unchanged
-6. File mode (`-f`) reads file content, translates it, then passes translated content to ydotool via stdin
+1. The translator is stateless - each character is translated independently
+2. Multi-character values in KEYMAP are output as-is (used for dead key sequences)
+3. Characters not in KEYMAP pass through unchanged
+4. The wrapper passes through all `ydotool` options unchanged
+5. File mode (`-f`) reads file content, translates it, then passes translated content to ydotool via stdin
+6. Dev mode: layouts are also searched in `$(script_dir)/../layouts/` for development without installation
 
 ### System Integration
 
 - The wrapper and translator are copied to `/usr/bin/` and rely on absolute path `/usr/bin/ydotool-real`
 - Script resolution uses `readlink -f` to follow symlinks and find the translator in the same directory
 - Installation is idempotent (checks for existing `/usr/bin/ydotool-real`)
+- Config file is preserved on reinstall (only created if missing)
 - Requires root for system binary modification
 
 ### Debug Output
 
 Enable with `DEBUG=1` environment variable:
 - Logs to `/tmp/ydotool-translate-debug.log`
-- Shows original text, translated text, and full command executed
+- Shows detected layout, original text, translated text, and full command executed
 - File mode logs include file path, original content, and translated content
-- Useful for diagnosing translation issues

--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
 # ydotool-rebind
 
-A wrapper for `ydotool` that translates AZERTY keyboard input to QWERTY, allowing proper text input with French AZERTY keyboards.
+A wrapper for `ydotool` that translates keyboard input from non-QWERTY layouts to QWERTY, allowing proper text input with AZERTY, QWERTZ, and other keyboard layouts.
 
 ## What is this?
 
-`ydotool` is a Linux keyboard/mouse automation tool that internally uses QWERTY layout regardless of your system keyboard layout. This wrapper automatically translates AZERTY input to QWERTY before passing it to `ydotool`.
+`ydotool` is a Linux keyboard/mouse automation tool that internally uses QWERTY layout regardless of your system keyboard layout. This wrapper automatically translates input to QWERTY before passing it to `ydotool`.
 
-**Example:**
+**Example (French AZERTY):**
 
 - Input: `ydotool type "Bonjour"`
-- Without wrapper: Types `Vonjout` ❌
-- With wrapper: Types `Bonjour` ✅
+- Without wrapper: Types `Vonjout`
+- With wrapper: Types `Bonjour`
+
+## Supported layouts
+
+| Layout | Description | Key differences |
+|--------|-------------|-----------------|
+| `fr`   | French AZERTY | a/q, z/w, m swaps, accents |
+| `de`   | German QWERTZ | z/y swap, umlauts, sharp s |
+| `be`   | Belgian AZERTY | Similar to FR, different number row |
+| `it`   | Italian | QWERTY-based, accented vowels on special keys |
+| `es`   | Spanish | QWERTY-based, ñ, ç, ¡/¿, dead keys for accents |
+| `us`   | US QWERTY | Passthrough (no translation) |
 
 ## Installation
 
@@ -22,13 +33,37 @@ sudo ./install.sh
 
 **Requirements:** `ydotool` installed, Bash 4.0+, root access
 
+## Configuration
+
+The layout is detected automatically by cascade:
+
+1. `YDOTOOL_LAYOUT` environment variable
+2. `/etc/ydotool-rebind/config` file (`LAYOUT=fr`)
+3. `setxkbmap` auto-detection (X11)
+4. `localectl` auto-detection (systemd)
+5. Fallback: `fr`
+
+To change the default layout:
+
+```bash
+# Edit config file
+sudo nano /etc/ydotool-rebind/config
+# Set: LAYOUT=de
+
+# Or use environment variable
+YDOTOOL_LAYOUT=de ydotool type "Hallo Welt"
+```
+
 ## Usage
 
 After installation, use `ydotool` normally:
 
 ```bash
-# Types correctly with AZERTY keyboard
+# Types correctly with your keyboard layout
 ydotool type "Bonjour, ça va ?"
+
+# File mode
+ydotool type -f /path/to/file.txt
 
 # Other commands work as usual
 ydotool key Return
@@ -38,15 +73,22 @@ ydotool mousemove 100 100
 ## How it works
 
 1. Wrapper intercepts all `ydotool` commands
-2. For `type` commands: translates AZERTY → QWERTY
-3. Passes result to real `ydotool`
+2. For `type` commands: loads the keyboard layout mapping and translates text
+3. Passes translated result to real `ydotool`
 
 ## Supported characters
 
-- French accents: é, è, ê, à, ù, ç
-- Special characters: â, ô, û, ä, ö, ü
-- Ligatures: æ, œ
-- All AZERTY/QWERTY symbols
+- French accents: e, e, e, a, u, c (circumflex, diaeresis)
+- German umlauts: a, o, u, ss
+- Ligatures: ae, oe
+- All layout-specific symbols and key positions
+
+## Debug
+
+```bash
+DEBUG=1 ydotool type "test"
+# Log: /tmp/ydotool-translate-debug.log
+```
 
 ## Uninstall
 

--- a/install.sh
+++ b/install.sh
@@ -29,21 +29,37 @@ else
     mv /usr/bin/ydotool /usr/bin/ydotool-real
 fi
 
-# Install the wrapper
+# Install the wrapper and translator
 echo "Installing ydotool wrapper..."
 cp "$SCRIPT_DIR/src/ydotool-wrapper.sh"  /usr/bin/ydotool-wrapper.sh
 cp "$SCRIPT_DIR/src/ydotool-translate.sh"  /usr/bin/ydotool-translate.sh
 ln -sf /usr/bin/ydotool-wrapper.sh /usr/bin/ydotool
 chmod +x /usr/bin/ydotool-wrapper.sh
-
-# Make the translator executable
-echo "Setting up AZERTY to QWERTY translator..."
 chmod +x /usr/bin/ydotool-translate.sh
 
+# Install layouts
+echo "Installing keyboard layouts..."
+mkdir -p /etc/ydotool-rebind/layouts
+cp "$SCRIPT_DIR"/layouts/*.sh /etc/ydotool-rebind/layouts/
+chmod +r /etc/ydotool-rebind/layouts/*.sh
+
+# Create default config if it doesn't exist
+if [ ! -f /etc/ydotool-rebind/config ]; then
+    echo "Creating default config (LAYOUT=fr)..."
+    echo "LAYOUT=fr" > /etc/ydotool-rebind/config
+else
+    echo "Config already exists, keeping current settings"
+fi
+
 echo ""
-echo "✅ Installation successful!"
+echo "Installation successful!"
+echo ""
+echo "Configuration: /etc/ydotool-rebind/config"
+echo "Available layouts: $(ls /etc/ydotool-rebind/layouts/ | sed 's/\.sh//g' | tr '\n' ' ')"
 echo ""
 echo "Next steps:"
-echo "  1. Test with: ydotool type \"Hello\""
-echo "  2. Uninstall with: sudo ./uninstall.sh"
+echo "  1. Edit /etc/ydotool-rebind/config to set your layout (LAYOUT=fr|de|be|it)"
+echo "  2. Or set YDOTOOL_LAYOUT=xx environment variable"
+echo "  3. Test with: ydotool type \"Hello\""
+echo "  4. Uninstall with: sudo ./uninstall.sh"
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -31,12 +31,14 @@ fi
 
 # Install the wrapper
 echo "Installing ydotool wrapper..."
-ln -sf "$SCRIPT_DIR/src/ydotool-wrapper.sh" /usr/bin/ydotool
-chmod +x "$SCRIPT_DIR/src/ydotool-wrapper.sh"
+cp "$SCRIPT_DIR/src/ydotool-wrapper.sh"  /usr/bin/ydotool-wrapper.sh
+cp "$SCRIPT_DIR/src/ydotool-translate.sh"  /usr/bin/ydotool-translate.sh
+ln -sf /usr/bin/ydotool-wrapper.sh /usr/bin/ydotool
+chmod +x /usr/bin/ydotool-wrapper.sh
 
 # Make the translator executable
 echo "Setting up AZERTY to QWERTY translator..."
-chmod +x "$SCRIPT_DIR/src/ydotool-translate.sh"
+chmod +x /usr/bin/ydotool-translate.sh
 
 echo ""
 echo "✅ Installation successful!"

--- a/layouts/be.sh
+++ b/layouts/be.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Belgian AZERTY layout mapping to QWERTY
+# Source: /usr/share/X11/xkb/symbols/be (basic)
+#
+# Very similar to French AZERTY with differences on number row
+# and some special characters.
+#
+# Only non-identity mappings are listed.
+# Characters not in this map pass through unchanged.
+
+declare -A KEYMAP=(
+    # ===== NUMBER ROW =====
+    # Unshifted
+    ['&']='1'
+    ['é']='2'
+    ['"']='3'
+    ["'"]='4'
+    ['(']='5'
+    ['§']='6'     # BE has § here (FR has -)
+    ['è']='7'
+    ['!']='8'     # BE has ! here (FR has _)
+    ['ç']='9'
+    ['à']='0'
+    [')']='-'
+    ['-']='='     # BE has - at AE12 (FR has =)
+
+    # Shifted
+    ['1']='!'
+    ['2']='@'
+    ['3']='#'
+    ['4']='$'
+    ['5']='%'
+    ['6']='^'
+    ['7']='&'
+    ['8']='*'
+    ['9']='('
+    ['0']=')'
+    ['°']='_'
+    ['_']='+'     # BE has _ at Shift+AE12 (FR has +)
+
+    # Accented uppercase on number row
+    ['É']='2'
+    ['È']='7'
+    ['À']='0'
+    ['Ç']='9'
+    ['Ù']="'"
+
+    # ===== CIRCUMFLEX ACCENTS (dead key ^ at AD11 = [ on QWERTY) =====
+    ['â']='[q'
+    ['ê']='[e'
+    ['î']='[i'
+    ['ô']='[o'
+    ['û']='[u'
+    ['Â']='[Q'
+    ['Ê']='[E'
+    ['Î']='[I'
+    ['Ô']='[O'
+    ['Û']='[U'
+
+    # ===== DIAERESIS (dead key ¨ at Shift+AD11 = { on QWERTY) =====
+    ['ä']='{q'
+    ['ë']='{e'
+    ['ï']='{i'
+    ['ö']='{o'
+    ['ü']='{u'
+    ['Ä']='{Q'
+    ['Ë']='{E'
+    ['Ï']='{I'
+    ['Ö']='{O'
+    ['Ü']='{U'
+
+    # ===== ACUTE ACCENT (no easy dead key, fallback to base letter) =====
+    ['á']='q'
+    ['í']='i'
+    ['ó']='o'
+    ['ú']='u'
+    ['Á']='Q'
+    ['Í']='I'
+    ['Ó']='O'
+    ['Ú']='U'
+
+    # ===== GRAVE ACCENT =====
+    ['ò']='o'
+    ['ì']='i'
+    ['ù']="'"
+
+    # ===== LIGATURES =====
+    ['œ']='oe'
+    ['Œ']='OE'
+    ['æ']='ae'
+    ['Æ']='AE'
+    ['ñ']='n'
+    ['Ñ']='N'
+
+    # ===== LETTER ROWS =====
+    # Top row (AZERTY → QWERTY position)
+    ['a']='q'
+    ['z']='w'
+    ['A']='Q'
+    ['Z']='W'
+    # AD12: $ / * → QWERTY ] / }
+    ['$']=']'
+    ['*']='}'
+
+    # Home row
+    ['q']='a'
+    ['Q']='A'
+    ['m']=';'
+    ['M']=':'
+    # AC11 shifted: % → "
+    ['%']='"'
+    # BKSL: µ / £ → QWERTY \ / |
+    ['µ']='\\'
+    ['£']='|'
+
+    # Bottom row
+    ['w']='z'
+    ['W']='Z'
+    [',']='m'
+    [';']=','
+    [':']='.'
+    # AB10: = / + → QWERTY / / ?
+    ['=']='/'
+    ['+']='?'
+
+    # Shifted bottom row
+    ['?']='M'
+    ['.']='<'
+    ['/']='>'
+
+    # TLDE: ² / ³ → QWERTY ` / ~
+    ['²']='`'
+    ['³']='~'
+)

--- a/layouts/be.sh
+++ b/layouts/be.sh
@@ -8,7 +8,7 @@
 # Only non-identity mappings are listed.
 # Characters not in this map pass through unchanged.
 
-declare -A KEYMAP=(
+KEYMAP=(
     # ===== NUMBER ROW =====
     # Unshifted
     ['&']='1'

--- a/layouts/de.sh
+++ b/layouts/de.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# German QWERTZ layout mapping to QWERTY
+# Source: /usr/share/X11/xkb/symbols/de (basic) + latin(type4)
+#
+# Only non-identity mappings are listed.
+# Characters not in this map pass through unchanged.
+
+declare -A KEYMAP=(
+    # ===== NUMBER ROW (shifted differences) =====
+    ['"']='@'     # Shift+2: DE " → US @
+    ['§']='#'     # Shift+3: DE § → US #
+    ['&']='^'     # Shift+6: DE & → US ^
+    ['/']='&'     # Shift+7: DE / → US &
+    ['(']='*'     # Shift+8: DE ( → US *
+    [')']='('     # Shift+9: DE ) → US (
+    ['=']=')'     # Shift+0: DE = → US )
+    ['ß']='-'     # AE11 unshifted
+    ['?']='_'     # AE11 shifted
+    ['°']='~'     # TLDE shifted: DE ° → US ~
+
+    # ===== LETTER SWAPS =====
+    ['z']='y'     # AD06: DE z → US y
+    ['Z']='Y'
+    ['y']='z'     # AB01: DE y → US z
+    ['Y']='Z'
+
+    # ===== SPECIAL KEYS =====
+    # AD11: ü/Ü → QWERTY [/{
+    ['ü']='['
+    ['Ü']='{'
+    # AD12: +/* → QWERTY ]/}
+    ['+']=']'
+    ['*']='}'
+    # AC10: ö/Ö → QWERTY ;/:
+    ['ö']=';'
+    ['Ö']=':'
+    # AC11: ä/Ä → QWERTY '/"
+    ['ä']="'"
+    ['Ä']='"'
+    # BKSL: #/' → QWERTY \/|
+    ['#']='\\'
+    ["'"]='|'
+    # AB08 shifted: ; → <
+    [';']='<'
+    # AB09 shifted: : → >
+    [':']='>'
+    # AB10: -/_ → QWERTY //?
+    ['-']='/'
+    ['_']='?'
+
+    # ===== DEAD KEY ACCENTS =====
+    # Circumflex (dead_circumflex at TLDE → QWERTY `)
+    ['â']='`a'
+    ['ê']='`e'
+    ['î']='`i'
+    ['ô']='`o'
+    ['û']='`u'
+    ['Â']='`A'
+    ['Ê']='`E'
+    ['Î']='`I'
+    ['Ô']='`O'
+    ['Û']='`U'
+
+    # Acute accent (dead_acute at AE12 → QWERTY =)
+    ['á']='=a'
+    ['é']='=e'
+    ['í']='=i'
+    ['ó']='=o'
+    ['ú']='=u'
+    ['Á']='=A'
+    ['É']='=E'
+    ['Í']='=I'
+    ['Ó']='=O'
+    ['Ú']='=U'
+
+    # Grave accent (dead_grave at Shift+AE12 → QWERTY +)
+    ['à']='+a'
+    ['è']='+e'
+    ['ì']='+i'
+    ['ò']='+o'
+    ['ù']='+u'
+    ['À']='+A'
+    ['È']='+E'
+    ['Ì']='+I'
+    ['Ò']='+O'
+    ['Ù']='+U'
+
+    # Ligatures (expand to multi-char)
+    ['œ']='oe'
+    ['Œ']='OE'
+    ['æ']='ae'
+    ['Æ']='AE'
+    ['ñ']='n'
+    ['Ñ']='N'
+)

--- a/layouts/de.sh
+++ b/layouts/de.sh
@@ -5,7 +5,7 @@
 # Only non-identity mappings are listed.
 # Characters not in this map pass through unchanged.
 
-declare -A KEYMAP=(
+KEYMAP=(
     # ===== NUMBER ROW (shifted differences) =====
     ['"']='@'     # Shift+2: DE " → US @
     ['§']='#'     # Shift+3: DE § → US #

--- a/layouts/es.sh
+++ b/layouts/es.sh
@@ -8,7 +8,7 @@
 # Only non-identity mappings are listed.
 # Characters not in this map pass through unchanged.
 
-declare -A KEYMAP=(
+KEYMAP=(
     # ===== TLDE: º / ª → QWERTY ` / ~ =====
     ['º']='`'
     ['ª']='~'

--- a/layouts/es.sh
+++ b/layouts/es.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Spanish layout mapping to QWERTY
+# Source: /usr/share/X11/xkb/symbols/es (basic) + latin(type4)
+#
+# Spanish is QWERTY-based for letters (no swaps),
+# but has different special characters, ñ, and dead keys for accents.
+#
+# Only non-identity mappings are listed.
+# Characters not in this map pass through unchanged.
+
+declare -A KEYMAP=(
+    # ===== TLDE: º / ª → QWERTY ` / ~ =====
+    ['º']='`'
+    ['ª']='~'
+
+    # ===== NUMBER ROW (shifted differences from QWERTY) =====
+    ['"']='@'     # Shift+2: ES " → US @
+    ['·']='#'     # Shift+3: ES · (periodcentered) → US #
+    ['&']='^'     # Shift+6: ES & → US ^
+    ['/']='&'     # Shift+7: ES / → US &
+    ['(']='*'     # Shift+8: ES ( → US *
+    [')']='('     # Shift+9: ES ) → US (
+    ['=']=')'     # Shift+0: ES = → US )
+
+    # AE11: ' / ? → QWERTY - / _
+    ["'"]='-'
+    ['?']='_'
+
+    # AE12: ¡ / ¿ → QWERTY = / +
+    ['¡']='='
+    ['¿']='+'
+
+    # ===== SPECIAL KEYS =====
+    # AD12: + / * → QWERTY ] / }
+    ['+']=']'
+    ['*']='}'
+    # AC10: ñ / Ñ → QWERTY ; / :
+    ['ñ']=';'
+    ['Ñ']=':'
+    # BKSL: ç / Ç → QWERTY \ / |
+    ['ç']='\\'
+    ['Ç']='|'
+
+    # ===== BOTTOM ROW (shifted differences) =====
+    [';']='<'     # AB08 shifted: ES ; → US <
+    [':']='>'     # AB09 shifted: ES : → US >
+    ['-']='/'     # AB10 unshifted: ES - → US /
+    ['_']='?'     # AB10 shifted: ES _ → US ?
+
+    # ===== DEAD KEY ACCENTS =====
+    # Grave accent (dead_grave at AD11 unshifted → QWERTY [)
+    ['à']='[a'
+    ['è']='[e'
+    ['ì']='[i'
+    ['ò']='[o'
+    ['ù']='[u'
+    ['À']='[A'
+    ['È']='[E'
+    ['Ì']='[I'
+    ['Ò']='[O'
+    ['Ù']='[U'
+
+    # Circumflex (dead_circumflex at AD11 shifted → QWERTY {)
+    ['â']='{a'
+    ['ê']='{e'
+    ['î']='{i'
+    ['ô']='{o'
+    ['û']='{u'
+    ['Â']='{A'
+    ['Ê']='{E'
+    ['Î']='{I'
+    ['Ô']='{O'
+    ['Û']='{U'
+
+    # Acute accent (dead_acute at AC11 unshifted → QWERTY ')
+    ['á']="'a"
+    ['é']="'e"
+    ['í']="'i"
+    ['ó']="'o"
+    ['ú']="'u"
+    ['Á']="'A"
+    ['É']="'E"
+    ['Í']="'I"
+    ['Ó']="'O"
+    ['Ú']="'U"
+
+    # Diaeresis (dead_diaeresis at AC11 shifted → QWERTY ")
+    ['ä']='"a'
+    ['ë']='"e'
+    ['ï']='"i'
+    ['ö']='"o'
+    ['ü']='"u'
+    ['Ä']='"A'
+    ['Ë']='"E'
+    ['Ï']='"I'
+    ['Ö']='"O'
+    ['Ü']='"U'
+
+    # ===== LIGATURES =====
+    ['œ']='oe'
+    ['Œ']='OE'
+    ['æ']='ae'
+    ['Æ']='AE'
+)

--- a/layouts/fr.sh
+++ b/layouts/fr.sh
@@ -5,7 +5,7 @@
 # Only non-identity mappings are listed.
 # Characters not in this map pass through unchanged.
 
-declare -A KEYMAP=(
+KEYMAP=(
     # ===== NUMBER ROW =====
     # Unshifted
     ['&']='1'

--- a/layouts/fr.sh
+++ b/layouts/fr.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# French AZERTY layout mapping to QWERTY
+# Source: /usr/share/X11/xkb/symbols/fr (basic)
+#
+# Only non-identity mappings are listed.
+# Characters not in this map pass through unchanged.
+
+declare -A KEYMAP=(
+    # ===== NUMBER ROW =====
+    # Unshifted
+    ['&']='1'
+    ['é']='2'
+    ['"']='3'
+    ["'"]='4'
+    ['(']='5'
+    ['-']='6'
+    ['è']='7'
+    ['_']='8'
+    ['ç']='9'
+    ['à']='0'
+    [')']='-'
+
+    # Shifted (digits produce symbols on QWERTY)
+    ['1']='!'
+    ['2']='@'
+    ['3']='#'
+    ['4']='$'
+    ['5']='%'
+    ['6']='^'
+    ['7']='&'
+    ['8']='*'
+    ['9']='('
+    ['0']=')'
+    ['°']='_'
+
+    # Accented uppercase on number row
+    ['É']='2'
+    ['È']='7'
+    ['À']='0'
+    ['Ç']='9'
+    ['Ù']="'"
+
+    # ===== CIRCUMFLEX ACCENTS (dead key ^ = [ on QWERTY) =====
+    ['â']='[q'
+    ['ê']='[e'
+    ['î']='[i'
+    ['ô']='[o'
+    ['û']='[u'
+    ['Â']='[Q'
+    ['Ê']='[E'
+    ['Î']='[I'
+    ['Ô']='[O'
+    ['Û']='[U'
+
+    # ===== DIAERESIS (dead key ¨ = Shift+^ = { on QWERTY) =====
+    ['ä']='{q'
+    ['ë']='{e'
+    ['ï']='{i'
+    ['ö']='{o'
+    ['ü']='{u'
+    ['Ä']='{Q'
+    ['Ë']='{E'
+    ['Ï']='{I'
+    ['Ö']='{O'
+    ['Ü']='{U'
+
+    # ===== ACUTE ACCENT (no dead key, fallback to base letter) =====
+    ['á']='q'
+    ['í']='i'
+    ['ó']='o'
+    ['ú']='u'
+    ['Á']='Q'
+    ['Í']='I'
+    ['Ó']='O'
+    ['Ú']='U'
+
+    # ===== GRAVE ACCENT =====
+    ['ò']='o'
+    ['ì']='i'
+    ['ù']="'"
+
+    # ===== LIGATURES =====
+    ['œ']='oe'
+    ['Œ']='OE'
+    ['æ']='ae'
+    ['Æ']='AE'
+    ['ñ']='n'
+    ['Ñ']='N'
+
+    # ===== LETTER ROWS =====
+    # Top row (AZERTY → QWERTY position)
+    ['a']='q'
+    ['z']='w'
+    ['A']='Q'
+    ['Z']='W'
+
+    # Home row
+    ['q']='a'
+    ['Q']='A'
+    ['m']=';'
+    ['M']=':'
+
+    # Bottom row
+    ['w']='z'
+    ['W']='Z'
+    [',']='m'
+    [';']=','
+    [':']='.'
+    ['!']='/'
+
+    # Shifted bottom row
+    ['?']='M'
+    ['.']='<'
+    ['/']='>'
+    ['§']='?'
+)

--- a/layouts/it.sh
+++ b/layouts/it.sh
@@ -8,7 +8,7 @@
 # Only non-identity mappings are listed.
 # Characters not in this map pass through unchanged.
 
-declare -A KEYMAP=(
+KEYMAP=(
     # ===== TLDE: \ / | → QWERTY ` / ~ =====
     ['\']='`'
     ['|']='~'

--- a/layouts/it.sh
+++ b/layouts/it.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Italian layout mapping to QWERTY
+# Source: /usr/share/X11/xkb/symbols/it (basic) + latin(type4)
+#
+# Italian is quasi-QWERTY: same letter positions,
+# but different special characters and accented keys.
+#
+# Only non-identity mappings are listed.
+# Characters not in this map pass through unchanged.
+
+declare -A KEYMAP=(
+    # ===== TLDE: \ / | → QWERTY ` / ~ =====
+    ['\']='`'
+    ['|']='~'
+
+    # ===== NUMBER ROW (shifted differences from QWERTY) =====
+    ['"']='@'     # Shift+2: IT " → US @
+    ['£']='#'     # Shift+3: IT £ → US #
+    ['&']='^'     # Shift+6: IT & → US ^
+    ['/']='&'     # Shift+7: IT / → US &
+    ['(']='*'     # Shift+8: IT ( → US *
+    [')']='('     # Shift+9: IT ) → US (
+    ['=']=')'     # Shift+0: IT = → US )
+
+    # AE11: ' / ? → QWERTY - / _
+    ["'"]='-'
+    ['?']='_'
+
+    # AE12: ì / ^ → QWERTY = / +
+    ['ì']='='
+    ['^']='+'
+
+    # ===== SPECIAL KEYS =====
+    # AD11: è / é → QWERTY [ / {
+    ['è']='['
+    ['é']='{'
+    # AD12: + / * → QWERTY ] / }
+    ['+']=']'
+    ['*']='}'
+    # AC10: ò / ç → QWERTY ; / :
+    ['ò']=';'
+    ['ç']=':'
+    # AC11: à / ° → QWERTY ' / "
+    ['à']="'"
+    ['°']='"'
+    # BKSL: ù / § → QWERTY \ / |
+    ['ù']='\\'
+    ['§']='|'
+
+    # ===== BOTTOM ROW (shifted differences) =====
+    [';']='<'     # AB08 shifted: IT ; → US <
+    [':']='>'     # AB09 shifted: IT : → US >
+    ['-']='/'     # AB10 unshifted: IT - → US /
+    ['_']='?'     # AB10 shifted: IT _ → US ?
+
+    # ===== LIGATURES =====
+    ['œ']='oe'
+    ['Œ']='OE'
+    ['æ']='ae'
+    ['Æ']='AE'
+    ['ñ']='n'
+    ['Ñ']='N'
+)

--- a/src/ydotool-translate.sh
+++ b/src/ydotool-translate.sh
@@ -1,305 +1,196 @@
 #!/bin/bash
 
-# Script to translate AZERTY layout text to QWERTY layout for ydotool
-# Since ydotool uses QWERTY internally, text input in AZERTY needs translation
-# 
-# This script translates French AZERTY keyboard input to equivalent QWERTY keys
-# so that ydotool types the correct characters when run on an AZERTY system.
+# Generic keyboard layout translation engine for ydotool
+# Translates text from a source keyboard layout to QWERTY
+# so that ydotool types the correct characters on non-QWERTY systems.
 
-# Function to translate AZERTY to QWERTY
-translate_azerty_to_qwerty() {
+# Detect which keyboard layout to use
+# Cascade: YDOTOOL_LAYOUT env → config file → setxkbmap → localectl → fallback fr
+detect_layout() {
+    # 1. Environment variable
+    if [[ -n "$YDOTOOL_LAYOUT" ]]; then
+        echo "$YDOTOOL_LAYOUT"
+        return
+    fi
+
+    # 2. Config file
+    local config="/etc/ydotool-rebind/config"
+    if [[ -f "$config" ]]; then
+        local layout
+        layout=$(grep -m1 '^LAYOUT=' "$config" 2>/dev/null | cut -d= -f2)
+        if [[ -n "$layout" ]]; then
+            echo "$layout"
+            return
+        fi
+    fi
+
+    # 3. setxkbmap (X11)
+    if command -v setxkbmap &>/dev/null; then
+        local layout
+        layout=$(setxkbmap -query 2>/dev/null | grep -m1 '^layout:' | awk '{print $2}' | cut -d, -f1)
+        if [[ -n "$layout" ]]; then
+            echo "$layout"
+            return
+        fi
+    fi
+
+    # 4. localectl (systemd)
+    if command -v localectl &>/dev/null; then
+        local layout
+        layout=$(localectl status 2>/dev/null | grep -m1 'X11 Layout' | awk '{print $3}' | cut -d, -f1)
+        if [[ -n "$layout" ]]; then
+            echo "$layout"
+            return
+        fi
+    fi
+
+    # 5. Fallback
+    echo "fr"
+}
+
+# Load a layout file (declares KEYMAP associative array)
+load_layout() {
+    local layout="$1"
+
+    # Resolve script directory (follows symlinks)
+    local script_real_path
+    script_real_path="$(readlink -f "${BASH_SOURCE[0]}")"
+    local script_dir
+    script_dir="$(dirname "$script_real_path")"
+
+    # Search paths: installed location, then dev location
+    local layout_file=""
+    if [[ -f "/etc/ydotool-rebind/layouts/${layout}.sh" ]]; then
+        layout_file="/etc/ydotool-rebind/layouts/${layout}.sh"
+    elif [[ -f "${script_dir}/../layouts/${layout}.sh" ]]; then
+        layout_file="${script_dir}/../layouts/${layout}.sh"
+    fi
+
+    if [[ -z "$layout_file" ]]; then
+        echo "Error: layout '${layout}' not found" >&2
+        echo "Searched: /etc/ydotool-rebind/layouts/${layout}.sh" >&2
+        echo "          ${script_dir}/../layouts/${layout}.sh" >&2
+        exit 1
+    fi
+
+    # shellcheck source=/dev/null
+    source "$layout_file"
+}
+
+# Translate text using the loaded KEYMAP
+translate_text() {
     local text="$1"
     local result=""
-    
+
     for (( i=0; i<${#text}; i++ )); do
         char="${text:$i:1}"
-        
-        case "$char" in
-            # ===== NUMBERS ROW (Top row) =====
-            # AZERTY number keys (when not shifted)
-            '&') result+='1' ;;   # AZERTY & (unshifted 1) → QWERTY 1
-            'é') result+='2' ;;   # AZERTY é (unshifted 2) → QWERTY 2
-            '"') result+='3' ;;   # AZERTY " (unshifted 3) → QWERTY 3
-            "'") result+='4' ;;   # AZERTY ' (unshifted 4) → QWERTY 4
-            '(') result+='5' ;;   # AZERTY ( (unshifted 5) → QWERTY 5
-            '-') result+='6' ;;   # AZERTY - (unshifted 6) → QWERTY 6
-            'è') result+='7' ;;   # AZERTY è (unshifted 7) → QWERTY 7
-            '_') result+='8' ;;   # AZERTY _ (unshifted 8) → QWERTY 8
-            'ç') result+='9' ;;   # AZERTY ç (unshifted 9) → QWERTY 9
-            'à') result+='0' ;;   # AZERTY à (unshifted 0) → QWERTY 0
-            ')') result+='-' ;;   # AZERTY ) (shift 0) → QWERTY -
-            '=') result+='=' ;;   # AZERTY = → QWERTY =
-            
-            # AZERTY shifted numbers (shifted = symbols)
-            '1') result+='!' ;;   # AZERTY 1 (shifted &) → QWERTY !
-            '2') result+='@' ;;   # AZERTY 2 (shifted é) → QWERTY @
-            '3') result+='#' ;;   # AZERTY 3 (shifted ") → QWERTY #
-            '4') result+='$' ;;   # AZERTY 4 (shifted ') → QWERTY $
-            '5') result+='%' ;;   # AZERTY 5 (shifted () → QWERTY %
-            '6') result+='^' ;;   # AZERTY 6 (shifted -) → QWERTY ^
-            '7') result+='&' ;;   # AZERTY 7 (shifted è) → QWERTY &
-            '8') result+='*' ;;   # AZERTY 8 (shifted _) → QWERTY *
-            '9') result+='(' ;;   # AZERTY 9 (shifted ç) → QWERTY (
-            '0') result+=')' ;;   # AZERTY 0 (shifted à) → QWERTY )
-            '°') result+='_' ;;   # AZERTY ° (shift +) → QWERTY _
-            '+') result+='+' ;;   # AZERTY + (AZERTY key) → QWERTY +
-            
-            # Accented uppercase symbols
-            'É') result+='2' ;;   # AZERTY É → QWERTY 2
-            'È') result+='7' ;;   # AZERTY È → QWERTY 7
-            'À') result+='0' ;;   # AZERTY À → QWERTY 0
-            'Ç') result+='9' ;;   # AZERTY Ç → QWERTY 9
-            'Ù') result+="'" ;;   # AZERTY Ù → QWERTY '
-            
-            # ===== ACCENTED VOWELS =====
-            # Circumflex accent (lowercase) - dead key ^ = [ on QWERTY
-            'â') result+='[q' ;;  # ^ (dead) + a → [ + q
-            'ê') result+='[e' ;;  # ^ (dead) + e → [ + e
-            'î') result+='[i' ;;  # ^ (dead) + i → [ + i
-            'ô') result+='[o' ;;  # ^ (dead) + o → [ + o
-            'û') result+='[u' ;;  # ^ (dead) + u → [ + u
 
-            # Circumflex accent (uppercase)
-            'Â') result+='[Q' ;;
-            'Ê') result+='[E' ;;
-            'Î') result+='[I' ;;
-            'Ô') result+='[O' ;;
-            'Û') result+='[U' ;;
-
-            # Diaeresis/Umlaut (lowercase) - dead key ¨ = Shift+^ = { on QWERTY
-            'ä') result+='{q' ;;
-            'ë') result+='{e' ;;
-            'ï') result+='{i' ;;
-            'ö') result+='{o' ;;
-            'ü') result+='{u' ;;
-
-            # Diaeresis/Umlaut (uppercase)
-            'Ä') result+='{Q' ;;
-            'Ë') result+='{E' ;;
-            'Ï') result+='{I' ;;
-            'Ö') result+='{O' ;;
-            'Ü') result+='{U' ;;
-
-            # Acute accent (lowercase) - no dead key on AZERTY, fallback to base letter
-            'á') result+='q' ;;
-            'í') result+='i' ;;
-            'ó') result+='o' ;;
-            'ú') result+='u' ;;
-
-            # Acute accent (uppercase)
-            'Á') result+='Q' ;;
-            'Í') result+='I' ;;
-            'Ó') result+='O' ;;
-            'Ú') result+='U' ;;
-            
-            # Grave accent (lowercase)
-            'ò') result+='o' ;;
-            'ì') result+='i' ;;
-            'ù') result+="'" ;;
-            
-            # Special ligatures
-            'œ') result+='oe' ;;
-            'Œ') result+='OE' ;;
-            'æ') result+='ae' ;;
-            'Æ') result+='AE' ;;
-            'ñ') result+='n' ;;
-            'Ñ') result+='N' ;;
-            
-            # ===== AZERTY LETTER ROWS =====
-            # AZERTY second row (ZERTY on French)
-            'a') result+='q' ;;   # AZERTY a → QWERTY q
-            'z') result+='w' ;;   # AZERTY z → QWERTY w
-            'e') result+='e' ;;   # AZERTY e → QWERTY e (same)
-            'r') result+='r' ;;   # AZERTY r → QWERTY r (same)
-            't') result+='t' ;;   # AZERTY t → QWERTY t (same)
-            'y') result+='y' ;;   # AZERTY y → QWERTY y (same)
-            'u') result+='u' ;;   # AZERTY u → QWERTY u (same)
-            'i') result+='i' ;;   # AZERTY i → QWERTY i (same)
-            'o') result+='o' ;;   # AZERTY o → QWERTY o (same)
-            'p') result+='p' ;;   # AZERTY p → QWERTY p (same)
-            
-            # AZERTY second row uppercase
-            'A') result+='Q' ;;
-            'Z') result+='W' ;;
-            'E') result+='E' ;;
-            'R') result+='R' ;;
-            'T') result+='T' ;;
-            'Y') result+='Y' ;;
-            'U') result+='U' ;;
-            'I') result+='I' ;;
-            'O') result+='O' ;;
-            'P') result+='P' ;;
-            
-            # AZERTY home row (QSDFG)
-            'q') result+='a' ;;   # AZERTY q → QWERTY a
-            's') result+='s' ;;   # AZERTY s → QWERTY s (same)
-            'd') result+='d' ;;   # AZERTY d → QWERTY d (same)
-            'f') result+='f' ;;   # AZERTY f → QWERTY f (same)
-            'g') result+='g' ;;   # AZERTY g → QWERTY g (same)
-            'h') result+='h' ;;   # AZERTY h → QWERTY h (same)
-            'j') result+='j' ;;   # AZERTY j → QWERTY j (same)
-            'k') result+='k' ;;   # AZERTY k → QWERTY k (same)
-            'l') result+='l' ;;   # AZERTY l → QWERTY l (same)
-            'm') result+=';' ;;   # AZERTY m → QWERTY ;
-            
-            # AZERTY home row uppercase
-            'Q') result+='A' ;;
-            'S') result+='S' ;;
-            'D') result+='D' ;;
-            'F') result+='F' ;;
-            'G') result+='G' ;;
-            'H') result+='H' ;;
-            'J') result+='J' ;;
-            'K') result+='K' ;;
-            'L') result+='L' ;;
-            'M') result+=':' ;;
-            
-            # AZERTY bottom row (WXCVBN)
-            'w') result+='z' ;;   # AZERTY w → QWERTY z
-            'x') result+='x' ;;   # AZERTY x → QWERTY x (same)
-            'c') result+='c' ;;   # AZERTY c → QWERTY c (same)
-            'v') result+='v' ;;   # AZERTY v → QWERTY v (same)
-            'b') result+='b' ;;   # AZERTY b → QWERTY b (same)
-            'n') result+='n' ;;   # AZERTY n → QWERTY n (same)
-            ',') result+='m' ;;   # AZERTY , → QWERTY m
-            ';') result+=',' ;;   # AZERTY ; → QWERTY ,
-            ':') result+='.' ;;   # AZERTY : → QWERTY .
-            '!') result+='/' ;;   # AZERTY ! (shift /) → QWERTY /
-            
-            # AZERTY bottom row uppercase
-            'W') result+='Z' ;;
-            'X') result+='X' ;;
-            'C') result+='C' ;;
-            'V') result+='V' ;;
-            'B') result+='B' ;;
-            'N') result+='N' ;;
-            '?') result+='M' ;;   # AZERTY ? → QWERTY M
-            '.') result+='<' ;;   # AZERTY . (shift ,) → QWERTY <
-            '/') result+='>' ;;   # AZERTY / (shift ;) → QWERTY >
-            '§') result+='?' ;;   # AZERTY § → QWERTY ?
-            
-            # ===== SPECIAL CHARACTERS =====
-            '[') result+='[' ;;   # Keep square brackets
-            ']') result+=']' ;;
-            '{') result+='{' ;;   # Keep curly braces
-            '}') result+='}' ;;
-            '(') result+='(' ;;   # Keep parentheses (already mapped above)
-            ')') result+=')' ;;
-            '<') result+='<' ;;   # Keep angle brackets
-            '>') result+='>' ;;
-            '\') result+='\\' ;;  # Keep backslash
-            '|') result+='|' ;;   # Keep pipe
-            '@') result+='@' ;;   # Keep at sign
-            '#') result+='#' ;;   # Keep hash
-            '~') result+='~' ;;   # Keep tilde
-            '`') result+='`' ;;   # Keep backtick
-            '^') result+='^' ;;   # Keep caret
-            '&') result+='&' ;;   # Keep ampersand (already mapped above)
-            '*') result+='*' ;;   # Keep asterisk
-            '%') result+='%' ;;   # Keep percent
-            '$') result+='$' ;;   # Keep dollar
-            
-            # ===== DEFAULT =====
-            # Keep all other characters as-is (space, newline, digits in text, etc.)
-            *) result+="$char" ;;
-        esac
+        if [[ -n "${KEYMAP[$char]+x}" ]]; then
+            result+="${KEYMAP[$char]}"
+        else
+            result+="$char"
+        fi
     done
-    
+
     echo "$result"
 }
-    
+
+# --- Main ---
+
+# Detect and load layout
+LAYOUT=$(detect_layout)
+
+# Short-circuit: no translation needed for US QWERTY
+if [[ "$LAYOUT" == "us" ]]; then
+    # Parse options, then pass everything through to ydotool-real
+    options=()
+    text="$*"
+    file_mode=0
+    file_path=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -d|--key-delay|-H|--key-hold|-D|--next-delay|-e|--escape)
+                options+=("$1" "$2"); shift 2 ;;
+            -f|--file)
+                file_mode=1; file_path="$2"; shift 2 ;;
+            -h|--help)
+                /usr/bin/ydotool-real type --help; exit 0 ;;
+            -d=*|--key-delay=*|-H=*|--key-hold=*|-D=*|--next-delay=*|-e=*|--escape=*)
+                options+=("$1"); shift ;;
+            -f=*|--file=*)
+                file_mode=1; file_path="${1#*=}"; shift ;;
+            --) shift; text="$*"; break ;;
+            -*) echo "Unknown option: $1" >&2; exit 1 ;;
+            *) text="$*"; break ;;
+        esac
+    done
+
+    if [ "$file_mode" -eq 1 ]; then
+        /usr/bin/ydotool-real type "${options[@]}" --file "$file_path"
+    else
+        /usr/bin/ydotool-real type "${options[@]}" "$text"
+    fi
+    exit $?
+fi
+
+# Load layout mapping
+load_layout "$LAYOUT"
+
 # Parse command line arguments
 options=()
 text="$*"
 file_mode=0
 file_path=""
 
-# Handle ydotool type command options
 while [ $# -gt 0 ]; do
     case "$1" in
         -d|--key-delay)
-            options+=("$1" "$2")
-            shift 2
-            ;;
+            options+=("$1" "$2"); shift 2 ;;
         -H|--key-hold)
-            options+=("$1" "$2")
-            shift 2
-            ;;
+            options+=("$1" "$2"); shift 2 ;;
         -D|--next-delay)
-            options+=("$1" "$2")
-            shift 2
-            ;;
+            options+=("$1" "$2"); shift 2 ;;
         -f|--file)
-            # File mode - need to translate file content
-            file_mode=1
-            file_path="$2"
-            shift 2
-            ;;
+            file_mode=1; file_path="$2"; shift 2 ;;
         -e|--escape)
-            options+=("$1" "$2")
-            shift 2
-            ;;
+            options+=("$1" "$2"); shift 2 ;;
         -h|--help)
-            # Pass through help to ydotool-real
-            /usr/bin/ydotool-real type --help
-            exit 0
-            ;;
+            /usr/bin/ydotool-real type --help; exit 0 ;;
         -d=*|--key-delay=*)
-            options+=("$1")
-            shift
-            ;;
+            options+=("$1"); shift ;;
         -H=*|--key-hold=*)
-            options+=("$1")
-            shift
-            ;;
+            options+=("$1"); shift ;;
         -D=*|--next-delay=*)
-            options+=("$1")
-            shift
-            ;;
+            options+=("$1"); shift ;;
         -f=*|--file=*)
-            # File mode - need to translate file content
-            file_mode=1
-            file_path="${1#*=}"
-            shift
-            ;;
+            file_mode=1; file_path="${1#*=}"; shift ;;
         -e=*|--escape=*)
-            options+=("$1")
-            shift
-            ;;
+            options+=("$1"); shift ;;
         --)
-            shift
-            text="$*"
-            break
-            ;;
+            shift; text="$*"; break ;;
         -*)
-            echo "Unknown option: $1" >&2
-            exit 1
-            ;;
+            echo "Unknown option: $1" >&2; exit 1 ;;
         *)
-            # Rest is text to type
-            text="$*"
-            break
-            ;;
+            text="$*"; break ;;
     esac
 done
 
-# If file mode, read file content, translate it, and pass to ydotool-real
+# File mode: read, translate, pass via stdin
 if [ "$file_mode" -eq 1 ]; then
-    # Read from file or stdin
     if [ "$file_path" = "-" ]; then
         file_content=$(cat)
     else
         file_content=$(cat "$file_path")
     fi
 
-    # Translate the content
-    translated=$(translate_azerty_to_qwerty "$file_content")
+    translated=$(translate_text "$file_content")
 
-    # Debug output if DEBUG env var is set
     if [ -n "$DEBUG" ]; then
         {
             echo "=== File Mode Debug Log ==="
             echo "Timestamp: $(date)"
+            echo "Layout: $LAYOUT"
             echo "Full command: $0 $@"
             echo "Options: ${options[*]}"
             echo "File path: $file_path"
@@ -309,29 +200,25 @@ if [ "$file_mode" -eq 1 ]; then
         } >> /tmp/ydotool-translate-debug.log
     fi
 
-    # Pass translated content to ydotool-real via stdin (without adding newline)
     printf '%s' "$translated" | /usr/bin/ydotool-real type "${options[@]}" --file -
     exit $?
 fi
 
-# Translate AZERTY to QWERTY
+# Direct text mode: translate and type
+translated=$(translate_text "$text")
 
-translated=$(translate_azerty_to_qwerty "$text")
-
-# Debug output if DEBUG env var is set
 if [ -n "$DEBUG" ]; then
     {
         echo "=== Command Debug Log ==="
         echo "Timestamp: $(date)"
+        echo "Layout: $LAYOUT"
         echo "Full command: $0 $@"
         echo "Options: ${options[*]}"
         echo "Text: $text"
-        echo "File mode: $file_mode"
         echo "Translated: $translated"
         echo "Command executed: /usr/bin/ydotool-real type ${options[*]} \"$translated\""
         echo ""
     } >> /tmp/ydotool-translate-debug.log
 fi
 
-# Type the translated text using ydotool-real
 /usr/bin/ydotool-real type "${options[@]}" "$translated"

--- a/src/ydotool-translate.sh
+++ b/src/ydotool-translate.sh
@@ -52,40 +52,40 @@ translate_azerty_to_qwerty() {
             'Ù') result+="'" ;;   # AZERTY Ù → QWERTY '
             
             # ===== ACCENTED VOWELS =====
-            # Circumflex accent (lowercase)
-            'â') result+='q' ;;   # AZERTY â → QWERTY q
-            'ê') result+='e' ;;   # AZERTY ê → QWERTY e
-            'î') result+='i' ;;   # AZERTY î → QWERTY i
-            'ô') result+='o' ;;   # AZERTY ô → QWERTY o
-            'û') result+='u' ;;   # AZERTY û → QWERTY u
-            
+            # Circumflex accent (lowercase) - dead key ^ = [ on QWERTY
+            'â') result+='[q' ;;  # ^ (dead) + a → [ + q
+            'ê') result+='[e' ;;  # ^ (dead) + e → [ + e
+            'î') result+='[i' ;;  # ^ (dead) + i → [ + i
+            'ô') result+='[o' ;;  # ^ (dead) + o → [ + o
+            'û') result+='[u' ;;  # ^ (dead) + u → [ + u
+
             # Circumflex accent (uppercase)
-            'Â') result+='Q' ;;
-            'Ê') result+='E' ;;
-            'Î') result+='I' ;;
-            'Ô') result+='O' ;;
-            'Û') result+='U' ;;
-            
-            # Diaeresis/Umlaut (lowercase)
-            'ä') result+='q' ;;
-            'ë') result+='e' ;;
-            'ï') result+='i' ;;
-            'ö') result+='o' ;;
-            'ü') result+='u' ;;
-            
+            'Â') result+='[Q' ;;
+            'Ê') result+='[E' ;;
+            'Î') result+='[I' ;;
+            'Ô') result+='[O' ;;
+            'Û') result+='[U' ;;
+
+            # Diaeresis/Umlaut (lowercase) - dead key ¨ = Shift+^ = { on QWERTY
+            'ä') result+='{q' ;;
+            'ë') result+='{e' ;;
+            'ï') result+='{i' ;;
+            'ö') result+='{o' ;;
+            'ü') result+='{u' ;;
+
             # Diaeresis/Umlaut (uppercase)
-            'Ä') result+='Q' ;;
-            'Ë') result+='E' ;;
-            'Ï') result+='I' ;;
-            'Ö') result+='O' ;;
-            'Ü') result+='U' ;;
-            
-            # Acute accent (lowercase)
+            'Ä') result+='{Q' ;;
+            'Ë') result+='{E' ;;
+            'Ï') result+='{I' ;;
+            'Ö') result+='{O' ;;
+            'Ü') result+='{U' ;;
+
+            # Acute accent (lowercase) - no dead key on AZERTY, fallback to base letter
             'á') result+='q' ;;
             'í') result+='i' ;;
             'ó') result+='o' ;;
             'ú') result+='u' ;;
-            
+
             # Acute accent (uppercase)
             'Á') result+='Q' ;;
             'Í') result+='I' ;;
@@ -309,8 +309,8 @@ if [ "$file_mode" -eq 1 ]; then
         } >> /tmp/ydotool-translate-debug.log
     fi
 
-    # Pass translated content to ydotool-real via stdin
-    echo "$translated" | /usr/bin/ydotool-real type "${options[@]}" --file -
+    # Pass translated content to ydotool-real via stdin (without adding newline)
+    printf '%s' "$translated" | /usr/bin/ydotool-real type "${options[@]}" --file -
     exit $?
 fi
 

--- a/src/ydotool-translate.sh
+++ b/src/ydotool-translate.sh
@@ -97,6 +97,10 @@ translate_text() {
 
 # --- Main ---
 
+# Declare KEYMAP at global scope (must be here, not inside load_layout,
+# otherwise declare -A inside a function makes it local)
+declare -A KEYMAP
+
 # Detect and load layout
 LAYOUT=$(detect_layout)
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -23,4 +23,10 @@ else
     echo "/usr/bin/ydotool-real not found"
 fi
 
-echo "✅ Uninstallation successful!"
+# Remove config and layouts
+if [ -d /etc/ydotool-rebind ]; then
+    echo "Removing configuration and layouts..."
+    rm -rf /etc/ydotool-rebind
+fi
+
+echo "Uninstallation successful!"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -16,6 +16,8 @@ fi
 if [ -f /usr/bin/ydotool-real ]; then
     echo "Restoring real ydotool..."
     rm -f /usr/bin/ydotool
+    rm -f /usr/bin/ydotool-wrapper.sh
+    rm -f /usr/bin/ydotool-translate.sh
     mv /usr/bin/ydotool-real /usr/bin/ydotool
 else
     echo "/usr/bin/ydotool-real not found"


### PR DESCRIPTION
## Résumé

Refactoring complet du moteur de traduction pour supporter plusieurs layouts clavier au lieu du seul AZERTY français hardcodé.

- **Moteur générique** : le case statement de 280 lignes est remplacé par un système `declare -A KEYMAP` avec fichiers de layout séparés
- **5 layouts** : français (fr), allemand (de), belge (be), italien (it), espagnol (es) + passthrough pour US
- **Détection automatique** : cascade `YDOTOOL_LAYOUT` → `/etc/ydotool-rebind/config` → `setxkbmap` → `localectl` → fallback `fr`
- **Rétrocompatibilité** : le layout FR produit des résultats identiques à l'ancien code

## Fichiers modifiés

| Fichier | Description |
|---------|-------------|
| `layouts/fr.sh` | AZERTY français (82 entrées) |
| `layouts/de.sh` | QWERTZ allemand (64 entrées) |
| `layouts/be.sh` | AZERTY belge (91 entrées) |
| `layouts/it.sh` | Italien (33 entrées) |
| `layouts/es.sh` | Espagnol (67 entrées) |
| `src/ydotool-translate.sh` | Moteur générique (detect + load + translate) |
| `install.sh` | Copie layouts dans `/etc/ydotool-rebind/layouts/` |
| `uninstall.sh` | Nettoie `/etc/ydotool-rebind/` |

## Plan de test

- [x] Layout FR : résultats identiques à l'ancien case statement
- [x] Layout DE : z/y swap, umlauts, ß, dead keys (circumflex, acute, grave)
- [x] Layout BE : différences number row vs FR
- [x] Layout IT : accents sur touches dédiées
- [x] Layout ES : ñ, ç, ¡/¿, dead keys
- [x] Détection layout via `YDOTOOL_LAYOUT` env var
- [ ] Test réel avec `ydotoold` sur chaque layout
- [ ] Test installation/désinstallation complète